### PR TITLE
updated with mongo atlas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,9 @@ pipeline {
         DOCKER_IMAGE_FRONTEND = 'shivakumarreddy1/disease-detection-frontend'
         DOCKER_IMAGE_BACKEND = 'shivakumarreddy1/disease-detection-backend'
         DOCKER_TAG = "${BUILD_NUMBER}"
-        EC2_HOST = '65.0.179.239'
+        EC2_HOST = '13.203.210.134'
         EC2_USER = 'ubuntu'
+        MONGODB_PASSWORD = credentials('sage-mongo-atlas')
     }
     
     stages {
@@ -49,7 +50,7 @@ pipeline {
                 sshagent(['aws-ssh']) {
                     sh """
                         scp -o StrictHostKeyChecking=no deploy-ec2.sh ${EC2_USER}@${EC2_HOST}:/home/ubuntu/
-                        ssh -o StrictHostKeyChecking=no ${EC2_USER}@${EC2_HOST} "bash /home/ubuntu/deploy-ec2.sh ${DOCKER_TAG}"
+                        ssh -o StrictHostKeyChecking=no ${EC2_USER}@${EC2_HOST} "bash /home/ubuntu/deploy-ec2.sh ${DOCKER_TAG} ${MONGODB_PASSWORD}"
                     """
                 }
             }

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose');
 
 const connectDB = async () => {
   try {
-    await mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost:27017/disease_detection', {
+    const mongoURI = process.env.MONGODB_URI || 'mongodb://localhost:27017/disease_detection';
+    await mongoose.connect(mongoURI, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });

--- a/backend/routes/prediction.js
+++ b/backend/routes/prediction.js
@@ -48,7 +48,7 @@ router.post('/predict', async (req, res) => {
       .filter(symptom => symptom !== null);
 
     // Make request to FastAPI endpoint
-    const response = await axios.post('http://65.0.179.239:8000/predict', {
+    const response = await axios.post('http://13.203.210.134:8000/predict', {
       symptoms: symptoms
     });
 

--- a/backend/routes/prediction.js
+++ b/backend/routes/prediction.js
@@ -48,11 +48,7 @@ router.post('/predict', async (req, res) => {
       .filter(symptom => symptom !== null);
 
     // Make request to FastAPI endpoint
-<<<<<<< HEAD
-    const response = await axios.post('http://localhost:8000/predict', {
-=======
     const response = await axios.post('http://65.0.179.239:8000/predict', {
->>>>>>> 296b21d6840d3aa7c041b6f5b7900e234fc62106
       symptoms: symptoms
     });
 

--- a/deploy-ec2.sh
+++ b/deploy-ec2.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# Usage: ./deploy-ec2.sh <TAG>
+# Usage: ./deploy-ec2.sh <TAG> <MONGODB_PASSWORD>
 TAG=$1
+MONGODB_PASSWORD=$2
+MONGODB_URI="mongodb+srv://chenreddyshivakumar1:${MONGODB_PASSWORD}@cluster0.l99afwo.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0"
 
-if [ -z "$TAG" ]; then
-  echo "Error: Docker tag not provided."
-  echo "Usage: ./deploy-ec2.sh <TAG>"
+if [ -z "$TAG" ] || [ -z "$MONGODB_PASSWORD" ]; then
+  echo "Error: Docker tag or MongoDB password not provided."
+  echo "Usage: ./deploy-ec2.sh <TAG> <MONGODB_PASSWORD>"
   exit 1
 fi
 
@@ -32,6 +34,7 @@ services:
       - NODE_ENV=production
       - PORT=5000
       - HOST=0.0.0.0
+      - MONGODB_URI=${MONGODB_URI}
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - NODE_ENV=production
       - PORT=5000
       - HOST=0.0.0.0
+      - MONGODB_URI=mongodb://localhost:27017/disease_detection
     networks:
       - app-network
 


### PR DESCRIPTION
I have enhanced your project’s deployment and security by refactoring the way your backend connects to MongoDB Atlas: instead of hardcoding sensitive information, It now securely inject the MongoDB password using Jenkins credentials (sage-mongo-atlas) during your CI/CD pipeline. The password is passed to your deployment script, which dynamically constructs the full connection string and sets it as an environment variable (MONGODB_URI) for your backend service, both in local development and production. Backend is now configured to always read the connection string from this environment variable, ensuring a consistent, secure, and environment-agnostic setup for database connectivity.